### PR TITLE
feat: domain grouping by eTLD+1 (Phase 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ __debug*
 .idea/
 .docs/
 /traffic-monitor
+CLAUDE.md
+release/
+vendor/

--- a/docs/superpowers/specs/2027-04-29-domain-grouping-design.md
+++ b/docs/superpowers/specs/2027-04-29-domain-grouping-design.md
@@ -1,0 +1,793 @@
+# Design: Domain Grouping & Traffic Labeling
+
+**Status:** Draft  
+**Scope:** Phase 1 (eTLD+1 auto-grouping) + Phase 2 (label_rules system)  
+**Last updated:** 2026-04-29
+
+---
+
+## Table of Contents
+
+1. [Problem Statement](#1-problem-statement)
+2. [Feature Summary](#2-feature-summary)
+3. [Design Decisions & Trade-offs](#3-design-decisions--trade-offs)
+4. [Architecture](#4-architecture)
+5. [Phase 1 — eTLD+1 Auto-Grouping](#5-phase-1--etld1-auto-grouping)
+6. [Phase 2 — Label Rules System](#6-phase-2--label-rules-system)
+7. [API Reference](#7-api-reference)
+8. [Data Models & Schema](#8-data-models--schema)
+9. [Future Work](#9-future-work)
+10. [Phase 1 Implementation Tasks](#10-phase-1-implementation-tasks)
+
+---
+
+## 1. Problem Statement
+
+### 1.1 CDN Hostname Fragmentation
+
+CDN-heavy services (YouTube, Netflix, etc.) distribute traffic across dozens of ephemeral, session-specific subdomains. A typical session produces entries like:
+
+```
+r1---sn-abc123.googlevideo.com      82 MB
+r4---sn-xyz789.googlevideo.com      61 MB
+rr3---sn-def456.googlevideo.com     47 MB
+r7---sn-ghi012.googlevideo.com      39 MB
+...  (20+ more rows)
+```
+
+The host list becomes noisy and the total YouTube traffic — the only number the user cares about — is invisible. The same pattern affects Akamai, Fastly, CloudFront, and virtually every major CDN.
+
+### 1.2 IP-Only Traffic (No Hostname)
+
+Mihomo routes traffic for some services entirely by IPCIDR rules, meaning no hostname is resolved or stored. Telegram is the canonical example:
+
+```
+91.108.56.111     12 MB
+91.108.56.100      8 MB
+149.154.167.41     6 MB
+...
+```
+
+The underlying ASN is `AS62041` (Telegram Messenger), but the dashboard shows raw IPs with no label. The user has to cross-reference Mihomo's ruleset manually to understand what service this is.
+
+### 1.3 Goal
+
+Show traffic grouped by **logical service**, not by DNS artifact or raw IP:
+
+```
+googlevideo.com    229 MB    ▶ (drill down to subdomains)
+Telegram           26 MB     ▶ (drill down to IPs)
+```
+
+---
+
+## 2. Feature Summary
+
+| | Phase 1 | Phase 2 |
+|---|---|---|
+| **What it does** | Auto-groups subdomains to eTLD+1 | User-defined rules with custom labels |
+| **Covers** | CDN fragmentation (YouTube, Netflix, etc.) | IP-only traffic (Telegram), custom labels, overrides |
+| **Rule source** | Automatic heuristic | Manual rules table |
+| **Config** | Global on/off toggle | Per-rule CRUD |
+| **Retroactive** | Yes — query-time, no rewrite | Yes — query-time, no rewrite |
+| **Requires DB change** | `app_settings` key only | New `label_rules` table |
+
+---
+
+## 3. Design Decisions & Trade-offs
+
+### 3.1 Where to Apply Grouping: Query-time vs. Write-time
+
+**Options considered:**
+
+| | Write-time (normalize on ingest) | Query-time (normalize on read) |
+|---|---|---|
+| Description | `normalizeHost()` called in `processConnections()`, stored normalized value | Raw host stored; normalization applied in query handlers |
+| Raw data preserved | No — original subdomain lost | Yes — full fidelity always available |
+| Retroactive rule changes | No — must re-ingest or rewrite rows | Yes — change rule, instant effect on all history |
+| Performance | Cheaper at read time | Cheap enough (in-memory, no SQL overhead) |
+| Rule-change cost | High (data migration or dual-store) | Zero |
+
+**Decision: Query-time.** The primary driver is retroactivity — when a user adds a CIDR rule for Telegram, they want it to apply to historical data immediately. Write-time would require either discarding history or maintaining a second normalized column. Raw data is also more valuable for future features (PSL upgrade, export, debugging).
+
+---
+
+### 3.2 eTLD+1: Heuristic vs. Public Suffix List (PSL)
+
+**The problem:** What does "last 2 domain parts" actually mean?
+
+```
+r1---sn-abc.googlevideo.com   → "last 2 parts" → googlevideo.com   ✓
+bbc.co.uk                     → "last 2 parts" → co.uk             ✗ (should be bbc.co.uk)
+user.github.io                → "last 2 parts" → github.io         ✗ (should be user.github.io)
+s3.amazonaws.com              → "last 2 parts" → amazonaws.com     ✗ (should be s3.amazonaws.com)
+```
+
+**Options:**
+
+| | Heuristic (last 2 parts) | Public Suffix List (PSL) |
+|---|---|---|
+| Correctness | ~95% for common cases | 100% per IANA/Mozilla data |
+| Dependencies | Zero | ~100 KB data file or external lib |
+| Multi-part TLDs (.co.uk) | Broken — strips too much | Correct |
+| Delegated registries (.github.io) | Broken — strips too much | Correct |
+| Complexity | ~10 lines | ~200 lines + data bundling |
+| Updatability | N/A | PSL data ages |
+
+**Decision: Heuristic for Phase 1, with a PSL seam.** The heuristic works for the primary use cases (CDN subdomains under single-part TLDs like `.com`, `.net`, `.io`). A single `normalizeHost(host string) string` function is the only place the heuristic lives — replacing it with a PSL implementation later requires changing exactly one function with zero API surface changes.
+
+**Known limitations of the heuristic:**
+- `bbc.co.uk` → groups to `co.uk` (wrong; all UK sites collapse)
+- `user.github.io` → groups to `github.io` (wrong; all GitHub Pages collapse)
+- `mybucket.s3.amazonaws.com` → groups to `amazonaws.com` (debatable)
+- Any ccTLD with 2-part registrations
+
+These are acceptable until PSL is implemented in a future phase.
+
+---
+
+### 3.3 Rule Storage: `app_settings` vs. Dedicated `label_rules` Table
+
+**`app_settings` (existing key-value store):**
+```sql
+CREATE TABLE IF NOT EXISTS app_settings (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL DEFAULT ''
+);
+```
+
+Storing rules here would require serializing a JSON array:
+```
+key: "label_rules"  value: '[{"type":"cidr","pattern":"91.108.0.0/16","label":"Telegram",...}]'
+```
+
+| | app_settings (JSON blob) | label_rules (dedicated table) |
+|---|---|---|
+| Individual rule CRUD | Full read-modify-write cycle on every change | Direct INSERT/UPDATE/DELETE by id |
+| Ordering | Must encode in JSON | `priority` column, ORDER BY |
+| SQL filtering | Cannot query by type/pattern/label | Full SQL expressivity |
+| Conflict detection | Manual JSON scan | UNIQUE constraint |
+| Future: Mihomo sync column | Adding to JSON schema | ALTER TABLE ADD COLUMN |
+| Existing pattern | Yes | No (new table) |
+
+**Decision: Dedicated `label_rules` table.** Rules are structured records needing individual CRUD and ordering — the key-value model is wrong for this. The "it needs a schema migration" concern is minimal: it's one `CREATE TABLE IF NOT EXISTS` block in `openDatabase()`, identical in complexity to every other table in the schema.
+
+---
+
+### 3.4 Drill-down UX: New View vs. Navigate to Substats
+
+When a user clicks a grouped row (e.g., `googlevideo.com 229 MB`), they should be able to see the underlying subdomains.
+
+**Options:**
+- **Inline expand:** Expand the row in place to show sub-rows
+- **Navigate to substats:** Reuse the existing drill-down pattern (click row → substats view filtered by that value)
+
+**Decision: Navigate to substats.** The substats view already exists, already handles filtering, already has its own trend/detail interactions. Building a new inline expand would duplicate that logic. The user explicitly selected this option.
+
+---
+
+### 3.5 Toggle Scope: Global vs. Per-dimension vs. Per-session
+
+**Decision: Global toggle in `app_settings`.** Stored as `domain_grouping_enabled` (`"1"` / `"0"`). A per-dimension toggle would complicate the UI and the query logic. Per-session (URL param) would be invisible to non-technical users. Global is the simplest contract: one checkbox in settings affects all views.
+
+---
+
+### 3.6 Chains-based View (Rejected)
+
+Mihomo already evaluates its ruleset and stores the matched proxy chain in the `chains` field. One could label Telegram traffic by detecting "TELEGRAM" in chains. This was considered and rejected because:
+
+- Not all users name their proxy groups after services
+- `chains` is a proxy routing artifact, not a service identity
+- It would work for Telegram only if a group literally named "Telegram" exists
+- Phase 2 CIDR rules solve the same problem generically
+
+---
+
+## 4. Architecture
+
+### 4.1 Overall Data Flow
+
+```
+Mihomo /connections
+        │
+        ▼
+processConnections()          ← raw host + IP stored as-is
+        │
+        ▼
+aggregateBuffer               ← in-memory 1-min buckets
+        │  (flush after 10 min)
+        ▼
+traffic_aggregated (SQLite)   ← raw host + IP persisted
+
+                              ┌─────────────────────────────────┐
+                              │   QUERY LAYER (new, Phase 1+2)  │
+                              │                                 │
+  HTTP request                │  1. Load label_rules from DB    │
+        │                     │  2. Read domain_grouping toggle │
+        ▼                     │  3. For each row:               │
+  queryAggregate()   ─────────►     applyLabel(host) →          │
+  queryByFilters()            │       Phase 2: exact match      │
+                              │       Phase 2: wildcard match   │
+                              │       Phase 2: CIDR match       │
+                              │       Phase 1: eTLD+1 fallback  │
+                              │  4. Merge rows sharing same     │
+                              │     normalized host/label       │
+                              │  5. Return to frontend          │
+                              └─────────────────────────────────┘
+```
+
+### 4.2 Label Resolution Pipeline
+
+```
+applyLabel(rawHost string, rules []labelRule, groupingEnabled bool) string
+          │
+          ├─ if !groupingEnabled → return rawHost (passthrough)
+          │
+          ├─ Phase 2: iterate rules by priority (ascending)
+          │     ├─ type="domain", pattern="telegram.org"
+          │     │     └─ exact match? → return rule.label
+          │     ├─ type="domain", pattern="*.googlevideo.com"
+          │     │     └─ wildcard match? → return rule.label
+          │     └─ type="cidr", pattern="91.108.0.0/16"
+          │           └─ rawHost is IP && IP in CIDR? → return rule.label
+          │
+          └─ Phase 1 fallback: normalizeHost(rawHost)
+                └─ normalizeHost("r1---sn-abc.googlevideo.com")
+                        → "googlevideo.com"
+```
+
+### 4.3 Rule Matching Order
+
+```
+Priority 1 (lowest number = checked first)
+    │
+    ├── exact domain   "telegram.org"           → literal string match
+    ├── wildcard       "*.googlevideo.com"       → suffix match after stripping "*."
+    ├── cidr           "91.108.0.0/16"           → net.ParseCIDR + IP contains
+    │
+    └── (no rule matched)
+           │
+           └── Phase 1 eTLD+1 heuristic         → last 2 parts of hostname
+                      │
+                      └── (rawHost is a bare IP) → return rawHost unchanged
+```
+
+### 4.4 Component Map
+
+```
+main.go
+  │
+  ├── openDatabase()
+  │     └── CREATE TABLE label_rules  (Phase 2)
+  │
+  ├── normalizeHost(host string) string         ← Phase 1 seam
+  │     └── strips all but last 2 domain parts
+  │
+  ├── applyLabel(host, rules, enabled) string   ← Phase 2 dispatcher
+  │     ├── matchExactDomain()
+  │     ├── matchWildcard()
+  │     ├── matchCIDR()
+  │     └── normalizeHost()  (fallback)
+  │
+  ├── loadLabelRules(db) []labelRule             ← Phase 2 loader
+  │
+  ├── queryAggregate()     ← apply label pipeline here
+  ├── queryByFilters()     ← apply label pipeline here
+  │
+  ├── handleLabelRules()   ← Phase 2 CRUD handler
+  │     ├── GET    → list all rules
+  │     ├── POST   → create rule
+  │     ├── PUT    → update rule by id
+  │     └── DELETE → delete rule by id
+  │
+  └── handleAggregate / handleSubstats
+        └── pass groupingEnabled from app_settings to queryAggregate
+```
+
+---
+
+## 5. Phase 1 — eTLD+1 Auto-Grouping
+
+### 5.1 Feature Behaviour
+
+When `domain_grouping_enabled = "1"` (default: on):
+
+- All query responses normalize `host` to its eTLD+1 before aggregating
+- Rows sharing the same normalized host are **summed** — upload, download, count all merged
+- The original subdomain is preserved in SQLite; normalization is query-time only
+- Drill-down from a grouped row navigates to the existing substats view with `host=googlevideo.com` filter
+
+When disabled:
+- All existing behaviour unchanged — raw hostnames returned
+
+### 5.2 `normalizeHost` Specification
+
+```go
+// normalizeHost returns the eTLD+1 of a hostname using a 2-part heuristic.
+// IP addresses and single-label hosts are returned unchanged.
+// Seam: replace the body of this function with a PSL lookup to upgrade accuracy.
+func normalizeHost(host string) string {
+    // Strip port if present
+    // Return bare IPs unchanged
+    // Return single-label hosts (e.g., "localhost") unchanged
+    // Split by ".", take last 2 parts
+    // Return "parts[n-2].parts[n-1]"
+}
+```
+
+Examples:
+
+| Input | Output | Notes |
+|---|---|---|
+| `r1---sn-abc.googlevideo.com` | `googlevideo.com` | CDN subdomain stripped |
+| `googlevideo.com` | `googlevideo.com` | Already eTLD+1 |
+| `www.youtube.com` | `youtube.com` | Normal subdomain stripped |
+| `91.108.56.111` | `91.108.56.111` | IP unchanged |
+| `localhost` | `localhost` | Single label unchanged |
+| `bbc.co.uk` | `co.uk` | Known limitation — PSL would fix |
+| `user.github.io` | `github.io` | Known limitation — PSL would fix |
+
+### 5.3 Query Aggregation Merge
+
+After applying `normalizeHost` (or `applyLabel` in Phase 2), the result set may have multiple rows with the same normalized host. These must be merged:
+
+```
+Before normalization:
+  r1---sn-abc.googlevideo.com   82 MB down,  1 MB up
+  r4---sn-xyz.googlevideo.com   61 MB down,  1 MB up
+  rr3---sn-def.googlevideo.com  47 MB down,  0 MB up
+
+After normalization + merge:
+  googlevideo.com              190 MB down,  2 MB up   count=3
+```
+
+This is a post-SQL in-memory reduction step — we do not modify the SQL query itself.
+
+### 5.4 Drill-down Behaviour
+
+When the user clicks `googlevideo.com` (normalized) in the host tab:
+
+- The substats endpoint receives `host=googlevideo.com`
+- The query handler detects this is a normalized (eTLD+1) host and runs a `LIKE '%googlevideo.com'` match against `traffic_aggregated.host`
+- The substats view shows all raw subdomains grouped under that domain
+
+Alternatively: pass a `raw=1` flag in the substats request to disable normalization for that call, showing the literal subdomains of the matched host.
+
+### 5.5 Settings Toggle
+
+Stored in `app_settings`:
+```
+key: "domain_grouping_enabled"   value: "1" (default) | "0"
+```
+
+Exposed via `GET/PUT /api/settings/mihomo` or a new settings endpoint. The toggle is displayed in the existing Settings modal alongside the Mihomo URL config.
+
+---
+
+## 6. Phase 2 — Label Rules System
+
+### 6.1 Feature Behaviour
+
+Users can define custom rules that map patterns to human-readable labels:
+
+| Rule type | Pattern | Label | Effect |
+|---|---|---|---|
+| `cidr` | `91.108.0.0/16` | `Telegram` | All IPs in range show as "Telegram" |
+| `cidr` | `149.154.160.0/20` | `Telegram` | Same — multiple CIDRs per label OK |
+| `domain` | `*.googlevideo.com` | `YouTube CDN` | Overrides eTLD+1 for this domain |
+| `domain` | `netflix.com` | `Netflix` | Exact domain match |
+
+Rules are evaluated before the eTLD+1 fallback, in ascending `priority` order. A matching rule short-circuits — no further rules checked.
+
+### 6.2 Rule Types
+
+**`type = "domain"`**
+- Pattern `"telegram.org"` → exact match against normalized host
+- Pattern `"*.googlevideo.com"` → wildcard: `host` ends with `.googlevideo.com`
+- Wildcard only supports leading `*` (e.g., `*.example.com`), not mid-string wildcards
+
+**`type = "cidr"`**
+- Pattern `"91.108.0.0/16"` → parsed as `net.IPNet`; matches when `rawHost` is a bare IP within that range
+- IPv4 and IPv6 both supported
+- Invalid CIDR patterns are skipped with a log warning (not a startup error)
+
+### 6.3 Matching Algorithm
+
+```
+for rule in sortedByPriority(enabledRules):
+    if rule.type == "domain":
+        if rule.pattern starts with "*." :
+            suffix = rule.pattern[1:]   // ".googlevideo.com"
+            if strings.HasSuffix(host, suffix): return rule.label
+        else:
+            if host == rule.pattern: return rule.label
+    else if rule.type == "cidr":
+        if isIPAddress(host):
+            ip = net.ParseIP(host)
+            if cidr.Contains(ip): return rule.label
+
+// no rule matched
+return normalizeHost(host)   // Phase 1 fallback
+```
+
+### 6.4 Rules UI (Settings Modal)
+
+A new "Label Rules" section in the settings modal:
+
+```
+┌─────────────────── Label Rules ───────────────────────────────────────┐
+│  [+ Add Rule]                                                         │
+│                                                                       │
+│  #   Pri  Type    Pattern             Label           Enabled         │
+│  ─── ──── ─────── ─────────────────── ─────────────── ───────         │
+│  1   10   cidr    91.108.0.0/16       Telegram        [✓]  [✎] [✗]   │
+│  2   10   cidr    149.154.160.0/20    Telegram        [✓]  [✎] [✗]   │
+│  3   20   domain  *.googlevideo.com   YouTube CDN     [✓]  [✎] [✗]   │
+│                                                                       │
+│  [Save]                                                               │
+└───────────────────────────────────────────────────────────────────────┘
+```
+
+Inline edit form appears when `[✎]` is clicked. Rows reorder by priority automatically.
+
+### 6.5 Rule Caching
+
+Label rules are loaded from SQLite on each query. For Phase 2 this is acceptable (rules list is small, <100 rows typical). A future optimization could cache rules in `service` struct and invalidate on write.
+
+---
+
+## 7. API Reference
+
+### 7.1 Existing Endpoints (Modified Behaviour)
+
+| Endpoint | Change |
+|---|---|
+| `GET /api/traffic/aggregate` | When `domain_grouping_enabled=1`, returns normalized/labeled hosts; rows merged |
+| `GET /api/traffic/substats` | Accepts normalized host as filter; runs LIKE match on raw `host` column |
+| `GET /api/traffic/trend` | Same normalization applied to host dimension |
+
+**New query parameter (Phase 1):**
+```
+GET /api/traffic/aggregate?raw=1
+```
+Disables grouping for this request (e.g., for drill-down into raw subdomains).
+
+### 7.2 New Endpoints (Phase 2)
+
+```
+GET    /api/label-rules              List all rules (ordered by priority)
+POST   /api/label-rules              Create a rule
+PUT    /api/label-rules/{id}         Update a rule
+DELETE /api/label-rules/{id}         Delete a rule
+PATCH  /api/label-rules/{id}/toggle  Enable/disable a rule
+```
+
+### 7.3 Settings Endpoint Extension (Phase 1)
+
+```
+GET  /api/settings/mihomo
+PUT  /api/settings/mihomo
+
+Extended response body:
+{
+  "url": "http://localhost:9090",
+  "secret": "...",
+  "domainGroupingEnabled": true      ← new field
+}
+```
+
+### 7.4 `GET /api/label-rules` Response
+
+```json
+[
+  {
+    "id": 1,
+    "type": "cidr",
+    "pattern": "91.108.0.0/16",
+    "label": "Telegram",
+    "priority": 10,
+    "enabled": true
+  },
+  {
+    "id": 3,
+    "type": "domain",
+    "pattern": "*.googlevideo.com",
+    "label": "YouTube CDN",
+    "priority": 20,
+    "enabled": true
+  }
+]
+```
+
+### 7.5 `POST /api/label-rules` Request Body
+
+```json
+{
+  "type": "cidr",
+  "pattern": "91.108.0.0/16",
+  "label": "Telegram",
+  "priority": 10,
+  "enabled": true
+}
+```
+
+Validation:
+- `type` must be `"domain"` or `"cidr"`
+- `pattern` must be non-empty; for `cidr` type, must be parseable by `net.ParseCIDR`
+- `label` must be non-empty
+- `priority` must be >= 0
+
+---
+
+## 8. Data Models & Schema
+
+### 8.1 Existing Schema (unchanged)
+
+```sql
+-- Primary query table — raw host values stored, never normalized
+CREATE TABLE IF NOT EXISTS traffic_aggregated (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    bucket_start INTEGER NOT NULL,
+    bucket_end   INTEGER NOT NULL,
+    source_ip    TEXT NOT NULL,
+    host         TEXT NOT NULL,         -- raw: "r1---sn-abc.googlevideo.com" or "91.108.56.111"
+    destination_ip TEXT NOT NULL DEFAULT '',
+    process      TEXT NOT NULL,
+    outbound     TEXT NOT NULL,
+    chains       TEXT NOT NULL DEFAULT '[]',
+    upload       INTEGER NOT NULL,
+    download     INTEGER NOT NULL,
+    count        INTEGER NOT NULL,
+    UNIQUE(bucket_start, bucket_end, source_ip, host, destination_ip, process, outbound, chains)
+);
+
+-- Scalar config store
+CREATE TABLE IF NOT EXISTS app_settings (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL DEFAULT ''
+);
+-- Existing keys: mihomo_url, mihomo_secret, auto_switch_enabled,
+--               auto_switch_threshold_*, auto_switch_window_*
+-- New key (Phase 1): domain_grouping_enabled
+```
+
+### 8.2 New: `label_rules` Table (Phase 2)
+
+```sql
+CREATE TABLE IF NOT EXISTS label_rules (
+    id       INTEGER PRIMARY KEY AUTOINCREMENT,
+    type     TEXT    NOT NULL CHECK(type IN ('domain', 'cidr')),
+    pattern  TEXT    NOT NULL,
+    label    TEXT    NOT NULL,
+    priority INTEGER NOT NULL DEFAULT 100,
+    enabled  INTEGER NOT NULL DEFAULT 1
+    -- future: source TEXT DEFAULT 'manual'  (for Mihomo sync)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_label_rules_pattern
+    ON label_rules(type, pattern);
+
+CREATE INDEX IF NOT EXISTS idx_label_rules_priority
+    ON label_rules(priority ASC, id ASC);
+```
+
+**Column notes:**
+- `type`: enum enforced by CHECK constraint
+- `pattern`: unique per type — same CIDR can't appear twice
+- `priority`: lower = checked first; ties broken by `id`
+- `enabled`: 0/1 integer (SQLite has no boolean type)
+- `source` column (commented out): reserved for Phase 3 Mihomo rule sync without a schema change
+
+### 8.3 Go Structs
+
+```go
+// Phase 1
+// normalizeHost encapsulates the eTLD+1 heuristic.
+// This function is the sole seam for a future PSL upgrade.
+func normalizeHost(host string) string { ... }
+
+// Phase 2
+type labelRule struct {
+    ID       int64  `json:"id"`
+    Type     string `json:"type"`     // "domain" | "cidr"
+    Pattern  string `json:"pattern"`
+    Label    string `json:"label"`
+    Priority int    `json:"priority"`
+    Enabled  bool   `json:"enabled"`
+}
+
+// applyLabel resolves a raw host to its display label.
+// Rules are evaluated in priority order; normalizeHost is the fallback.
+func applyLabel(host string, rules []labelRule, groupingEnabled bool) string { ... }
+```
+
+---
+
+## 9. Future Work
+
+### 9.1 PSL Upgrade (Phase 3)
+
+Replace the body of `normalizeHost()` with a proper Public Suffix List lookup:
+
+- Bundle `public_suffix_list.dat` as an embedded asset (≈100 KB)
+- Use `golang.org/x/net/publicsuffix` or a custom parser
+- Zero API surface changes — `normalizeHost` signature stays identical
+- Fixes `bbc.co.uk → co.uk` and `user.github.io → github.io` regressions
+
+### 9.2 Mihomo Rule Sync (Phase 3)
+
+Import IPCIDR and DOMAIN rules directly from Mihomo's parsed ruleset:
+
+```
+GET {mihomo}/rules   → [{type:"IPCIDR", payload:"91.108.0.0/16", proxy:"TELEGRAM"}, ...]
+```
+
+Map Mihomo rule types to `label_rules`:
+- `IPCIDR` → `type="cidr"`
+- `DOMAIN-SUFFIX` → `type="domain"`, prefix with `*.`
+- `DOMAIN` → `type="domain"`
+
+The reserved `source TEXT DEFAULT 'manual'` column distinguishes synced from user-defined rules. Synced rules would be read-only in the UI.
+
+To enable: add the `source` column via `ALTER TABLE label_rules ADD COLUMN source TEXT DEFAULT 'manual'` (no data loss).
+
+### 9.3 Rule Performance Cache
+
+For high-throughput environments, cache `[]labelRule` in the `service` struct:
+
+```go
+type service struct {
+    ...
+    labelRulesMu    sync.RWMutex
+    labelRulesCache []labelRule
+    labelRulesDirty bool
+}
+```
+
+Invalidate on any write to `label_rules`. Load on first query after invalidation.
+
+### 9.4 Per-dimension Toggle
+
+Allow grouping on `host` dimension but not `sourceIP` or `outbound`. Would require `domain_grouping_enabled` to become a per-dimension setting or a query parameter.
+
+---
+
+## 10. Phase 1 Implementation Tasks
+
+All changes are in `main.go` and `web/` unless noted. No new files required.
+
+---
+
+### Task 1: `normalizeHost()` function
+
+**File:** `main.go`  
+**Location:** After existing helper functions, before query handlers (~line 1630)
+
+```go
+func normalizeHost(host string) string {
+    // 1. Strip port (host may be "example.com:443")
+    // 2. Return bare IPs unchanged (net.ParseIP != nil)
+    // 3. Split by ".", if len(parts) <= 2 return host unchanged
+    // 4. Return parts[len-2] + "." + parts[len-1]
+}
+```
+
+Write unit tests in `main_test.go` covering:
+- CDN subdomain (`r1---sn-abc.googlevideo.com` → `googlevideo.com`)
+- Bare IPv4 (`91.108.56.111` → unchanged)
+- Bare IPv6 (`2001:db8::1` → unchanged)
+- Already eTLD+1 (`youtube.com` → unchanged)
+- Single label (`localhost` → unchanged)
+- Host with port (`example.com:443` → `example.com`)
+- Three-part domain (`www.youtube.com` → `youtube.com`)
+
+---
+
+### Task 2: `domain_grouping_enabled` setting
+
+**File:** `main.go`
+
+2a. Add `domainGroupingEnabled bool` field to the response struct for `GET /api/settings/mihomo`.
+
+2b. In `handleMihomoSettings` GET handler: read `domain_grouping_enabled` from `app_settings`, include in response.
+
+2c. In `handleMihomoSettings` PUT handler: accept and persist `domainGroupingEnabled` to `app_settings`.
+
+2d. Add helper `loadDomainGroupingEnabled(db *sql.DB) bool` — defaults to `true` if key absent.
+
+---
+
+### Task 3: Post-query merge in `queryAggregate`
+
+**File:** `main.go`  
+**Location:** `queryAggregate()` and any callers that build `[]aggregatedData`
+
+3a. After building the raw result slice, if `groupingEnabled`:
+- For each row, replace `row.Label` (the host) with `normalizeHost(row.Label)`
+- Accumulate into a `map[string]*aggregatedData`
+- Merge: `upload += row.Upload`, `download += row.Download`, `count += row.Count`
+- Convert map back to sorted slice
+
+3b. Ensure `handleAggregate` passes `groupingEnabled` to `queryAggregate`.
+
+3c. Ensure `handleSubstats` **disables** normalization (always passes `groupingEnabled=false`) so the drill-down view always shows raw subdomains.
+
+---
+
+### Task 4: Substats drill-down — LIKE match for normalized hosts
+
+**File:** `main.go`  
+**Location:** `handleSubstats` / underlying query
+
+When `host` filter value is a normalized eTLD+1 (e.g., `googlevideo.com`) rather than a full subdomain, the existing `WHERE host = ?` will return zero rows.
+
+4a. Detect if the filter host is a normalized form: it matches its own `normalizeHost()` output AND is not an IP address.
+
+4b. If so, change the SQL predicate from `host = ?` to `host LIKE ?` with value `'%' + host`.
+
+4c. This ensures clicking `googlevideo.com` in the host tab shows all raw subdomains in substats.
+
+---
+
+### Task 5: `raw=1` query parameter (optional, but enables testing)
+
+**File:** `main.go`  
+**Location:** `handleAggregate`
+
+5a. If `?raw=1` is present in the request, set `groupingEnabled = false` regardless of the setting.
+
+5b. This allows the frontend (and tests) to compare normalized vs. raw output without toggling the global setting.
+
+---
+
+### Task 6: Settings UI toggle
+
+**File:** `web/app.js`, `web/index.html`, `web/styles.css`
+
+6a. In the Settings modal (existing), add a checkbox row: **"Group subdomains by root domain"**.
+
+6b. On modal open: `GET /api/settings/mihomo` → populate checkbox from `domainGroupingEnabled`.
+
+6c. On Save: include `domainGroupingEnabled` in the `PUT /api/settings/mihomo` body.
+
+6d. After save, refresh the currently active tab's data so the effect is immediately visible.
+
+---
+
+### Task 7: Unit tests
+
+**File:** `main_test.go`
+
+7a. `TestNormalizeHost` — all cases from Task 1 spec.
+
+7b. `TestQueryAggregateGrouping` — given a set of raw aggregatedData rows with CDN subdomains, assert the grouped output merges them correctly.
+
+7c. `TestDomainGroupingToggle` — assert that `raw=1` or `groupingEnabled=false` returns un-merged rows.
+
+---
+
+### Task 8: Integration smoke test (manual)
+
+Before marking Phase 1 complete:
+
+- [ ] Build and run: `go build -o traffic-monitor main.go && ./traffic-monitor`
+- [ ] Verify host tab shows `googlevideo.com` instead of 20+ subdomains
+- [ ] Click `googlevideo.com` → substats shows individual subdomains
+- [ ] Disable grouping in settings → host tab reverts to raw subdomains
+- [ ] Re-enable → grouping resumes, no data loss
+- [ ] `go test ./...` passes
+
+---
+
+### Phase 1 Task Summary
+
+| # | Task | Scope | Complexity |
+|---|---|---|---|
+| 1 | `normalizeHost()` function + tests | `main.go`, `main_test.go` | Low |
+| 2 | `domain_grouping_enabled` setting R/W | `main.go` | Low |
+| 3 | Post-query merge in `queryAggregate` | `main.go` | Medium |
+| 4 | Substats LIKE match for normalized hosts | `main.go` | Low |
+| 5 | `?raw=1` passthrough param | `main.go` | Low |
+| 6 | Settings UI toggle | `web/` | Low |
+| 7 | Unit tests | `main_test.go` | Medium |
+| 8 | Manual smoke test | — | Low |

--- a/main.go
+++ b/main.go
@@ -2087,7 +2087,8 @@ func (s *service) handleDevicesByHost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	data, err := s.queryByFilters("source_ip", "host = ?", []any{host}, start, end)
+	hostFilter, hostArgs := s.hostFilterArgs(host)
+	data, err := s.queryByFilters("source_ip", hostFilter, hostArgs, start, end)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err)
 		return
@@ -2247,13 +2248,26 @@ func groupHostRows(rows []aggregatedData) []aggregatedData {
 	return sortedAggregatedDataRows(merged)
 }
 
+// hostFilterArgs returns a SQL filter and args for matching a host column.
+// When domain grouping is enabled, expands a normalized host to also match subdomains via LIKE.
+func (s *service) hostFilterArgs(host string) (string, []any) {
+	if s.currentDomainGroupingEnabled() {
+		return "(host = ? OR host LIKE ?)", []any{host, "%." + host}
+	}
+	return "host = ?", []any{host}
+}
+
 func (s *service) querySubstats(dimension, label string, start, end int64) ([]aggregatedData, error) {
 	column, err := dimensionColumn(dimension)
 	if err != nil {
 		return nil, err
 	}
 	if column == "host" {
-		return nil, errors.New("host is not supported for substats")
+		if !s.currentDomainGroupingEnabled() {
+			return nil, errors.New("host substats require domain grouping to be enabled")
+		}
+		hostFilter, hostArgs := s.hostFilterArgs(label)
+		return s.queryByFilters("host", hostFilter, hostArgs, start, end)
 	}
 	return s.queryByFilters("host", column+" = ?", []any{label}, start, end)
 }
@@ -2287,6 +2301,17 @@ func (s *service) queryConnectionDetails(dimension, primary, secondary string, s
 	filter, args, err := detailFilter(dimension, primary, secondary)
 	if err != nil {
 		return nil, err
+	}
+	if dimension == "host" && s.currentDomainGroupingEnabled() {
+		if net.ParseIP(secondary) == nil {
+			// secondary is a raw subdomain — show all source IPs for that host
+			filter = "host = ?"
+			args = []any{secondary}
+		} else {
+			hostFilter, hostArgs := s.hostFilterArgs(primary)
+			filter = hostFilter + " AND source_ip = ?"
+			args = append(hostArgs, secondary)
+		}
 	}
 
 	rows, err := s.db.Query(`
@@ -2564,22 +2589,55 @@ func matchesAggregateEntryFilters(entry aggregatedEntry, filter string, args []a
 	}
 
 	clauses := strings.Split(filter, " AND ")
-	if len(clauses) != len(args) {
-		return false
-	}
-
-	for i, clause := range clauses {
+	argIdx := 0
+	for _, clause := range clauses {
+		clause = strings.TrimSpace(clause)
+		if argIdx >= len(args) {
+			return false
+		}
+		// Handle compound clause: (col = ? OR col LIKE ?)
+		// Used for normalized-host LIKE expansion. Consumes 2 args.
+		if strings.HasPrefix(clause, "(") && strings.HasSuffix(clause, ")") {
+			if argIdx+1 >= len(args) {
+				return false
+			}
+			inner := clause[1 : len(clause)-1]
+			parts := strings.SplitN(inner, " OR ", 2)
+			if len(parts) != 2 {
+				return false
+			}
+			col := strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(parts[0]), "= ?"))
+			col = strings.TrimSpace(strings.TrimSuffix(col, " = ?"))
+			fieldVal := aggregateEntryFieldValue(entry, col)
+			exactVal := fmt.Sprint(args[argIdx])
+			likePattern := fmt.Sprint(args[argIdx+1])
+			if fieldVal != exactVal && !matchesLikePattern(fieldVal, likePattern) {
+				return false
+			}
+			argIdx += 2
+			continue
+		}
+		// Handle simple clause: col = ?
 		column := strings.TrimSpace(strings.TrimSuffix(clause, "= ?"))
 		column = strings.TrimSpace(strings.TrimSuffix(column, " = ?"))
 		if column == "" {
 			return false
 		}
-		if aggregateEntryFieldValue(entry, column) != fmt.Sprint(args[i]) {
+		if aggregateEntryFieldValue(entry, column) != fmt.Sprint(args[argIdx]) {
 			return false
 		}
+		argIdx++
 	}
 
-	return true
+	return argIdx == len(args)
+}
+
+// matchesLikePattern matches the "%.suffix" pattern (prefix wildcard only).
+func matchesLikePattern(value, pattern string) bool {
+	if strings.HasPrefix(pattern, "%.") {
+		return strings.HasSuffix(value, pattern[1:])
+	}
+	return value == pattern
 }
 
 func aggregateEntryFieldValue(entry aggregatedEntry, column string) string {

--- a/main.go
+++ b/main.go
@@ -2008,7 +2008,8 @@ func (s *service) handleAggregate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	data, err := s.queryAggregate(dimension, start, end)
+	raw := r.URL.Query().Get("raw") == "1"
+	data, err := s.queryAggregate(dimension, start, end, raw)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err)
 		return
@@ -2214,7 +2215,7 @@ func (s *service) handleLogs(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
 }
 
-func (s *service) queryAggregate(dimension string, start, end int64) ([]aggregatedData, error) {
+func (s *service) queryAggregate(dimension string, start, end int64, raw bool) ([]aggregatedData, error) {
 	column, err := dimensionColumn(dimension)
 	if err != nil {
 		return nil, err
@@ -2223,7 +2224,7 @@ func (s *service) queryAggregate(dimension string, start, end int64) ([]aggregat
 	if err != nil {
 		return nil, err
 	}
-	if column == "host" && s.currentDomainGroupingEnabled() {
+	if column == "host" && !raw && s.currentDomainGroupingEnabled() {
 		rows = groupHostRows(rows)
 	}
 	return rows, nil

--- a/main.go
+++ b/main.go
@@ -169,21 +169,22 @@ type mihomoProxiesResponse struct {
 }
 
 type service struct {
-	db                *sql.DB
-	client            *http.Client
-	now               func() time.Time
-	cfg               config
-	mu                sync.Mutex
-	mihomoSettings    mihomoSettings
-	lastConnections   map[string]connection
-	lastUploadTotal   int64
-	lastDownloadTotal int64
-	lastAutoSwitchAt  int64
-	lastAutoSwitchMin int64
-	lastCleanup       time.Time
-	lastVacuum        time.Time
-	aggregateBuffer   map[string]*aggregatedEntry
-	hostMinuteWindows map[string]*hostTrafficWindow
+	db                    *sql.DB
+	client                *http.Client
+	now                   func() time.Time
+	cfg                   config
+	mu                    sync.Mutex
+	mihomoSettings        mihomoSettings
+	domainGroupingEnabled bool
+	lastConnections       map[string]connection
+	lastUploadTotal       int64
+	lastDownloadTotal     int64
+	lastAutoSwitchAt      int64
+	lastAutoSwitchMin     int64
+	lastCleanup           time.Time
+	lastVacuum            time.Time
+	aggregateBuffer       map[string]*aggregatedEntry
+	hostMinuteWindows     map[string]*hostTrafficWindow
 }
 
 type aggregatedEntry struct {
@@ -223,16 +224,19 @@ func main() {
 		log.Fatalf("resolve mihomo settings: %v", err)
 	}
 
+	domainGroupingEnabled := loadDomainGroupingEnabled(db)
+
 	svc := &service{
-		db:                db,
-		client:            &http.Client{Timeout: 10 * time.Second},
-		now:               time.Now,
-		cfg:               cfg,
-		mihomoSettings:    runtimeSettings,
-		lastConnections:   make(map[string]connection),
-		lastVacuum:        time.Now(),
-		aggregateBuffer:   make(map[string]*aggregatedEntry),
-		hostMinuteWindows: make(map[string]*hostTrafficWindow),
+		db:                    db,
+		client:                &http.Client{Timeout: 10 * time.Second},
+		now:                   time.Now,
+		cfg:                   cfg,
+		mihomoSettings:        runtimeSettings,
+		domainGroupingEnabled: domainGroupingEnabled,
+		lastConnections:       make(map[string]connection),
+		lastVacuum:            time.Now(),
+		aggregateBuffer:       make(map[string]*aggregatedEntry),
+		hostMinuteWindows:     make(map[string]*hostTrafficWindow),
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -467,6 +471,28 @@ func saveMihomoSettings(db *sql.DB, settings mihomoSettings) error {
 	}
 
 	return tx.Commit()
+}
+
+func loadDomainGroupingEnabled(db *sql.DB) bool {
+	var value string
+	err := db.QueryRow(`SELECT value FROM app_settings WHERE key = 'domain_grouping_enabled'`).Scan(&value)
+	if err != nil {
+		return true // default on
+	}
+	return value == "true"
+}
+
+func saveDomainGroupingEnabled(db *sql.DB, enabled bool) error {
+	value := "false"
+	if enabled {
+		value = "true"
+	}
+	_, err := db.Exec(`
+		INSERT INTO app_settings (key, value)
+		VALUES ('domain_grouping_enabled', ?)
+		ON CONFLICT(key) DO UPDATE SET value = excluded.value
+	`, value)
+	return err
 }
 
 func resolveMihomoSettings(db *sql.DB, envURL, envSecret string) (mihomoSettings, error) {
@@ -979,6 +1005,22 @@ func (s *service) updateMihomoSettings(settings mihomoSettings) error {
 		return err
 	}
 	s.setMihomoSettings(settings)
+	return nil
+}
+
+func (s *service) currentDomainGroupingEnabled() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.domainGroupingEnabled
+}
+
+func (s *service) updateDomainGroupingEnabled(enabled bool) error {
+	if err := saveDomainGroupingEnabled(s.db, enabled); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	s.domainGroupingEnabled = enabled
+	s.mu.Unlock()
 	return nil
 }
 
@@ -1771,6 +1813,7 @@ func (s *service) routes() http.Handler {
 	mux.Handle("/", fileServer)
 	mux.HandleFunc("/health", s.handleHealth)
 	mux.HandleFunc("/api/settings/mihomo", s.handleMihomoSettings)
+	mux.HandleFunc("/api/settings/domain-grouping", s.handleDomainGroupingSettings)
 	mux.HandleFunc("/api/auto-switch/settings", s.handleAutoSwitchSettings)
 	mux.HandleFunc("/api/auto-switch/groups", s.handleAutoSwitchGroups)
 	mux.HandleFunc("/api/auto-switch/events", s.handleAutoSwitchEvents)
@@ -1845,6 +1888,29 @@ func (s *service) handleMihomoSettings(w http.ResponseWriter, r *http.Request) {
 		}
 
 		writeJSON(w, http.StatusOK, s.currentMihomoSettings())
+	default:
+		writeMethodNotAllowed(w)
+	}
+}
+
+func (s *service) handleDomainGroupingSettings(w http.ResponseWriter, r *http.Request) {
+	type domainGroupingResponse struct {
+		Enabled bool `json:"enabled"`
+	}
+	switch r.Method {
+	case http.MethodGet:
+		writeJSON(w, http.StatusOK, domainGroupingResponse{Enabled: s.currentDomainGroupingEnabled()})
+	case http.MethodPut:
+		var payload domainGroupingResponse
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			writeError(w, http.StatusBadRequest, errors.New("invalid json body"))
+			return
+		}
+		if err := s.updateDomainGroupingEnabled(payload.Enabled); err != nil {
+			writeError(w, http.StatusInternalServerError, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, domainGroupingResponse{Enabled: s.currentDomainGroupingEnabled()})
 	default:
 		writeMethodNotAllowed(w)
 	}

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io/fs"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -1625,6 +1626,25 @@ func (s *service) cleanupOldLogs(nowMS int64) error {
 	}
 
 	return nil
+}
+
+// normalizeHost returns the eTLD+1 of host, stripping subdomains.
+// Bare IPs and single-label names are returned unchanged.
+// This is the sole seam for a future Public Suffix List upgrade.
+func normalizeHost(host string) string {
+	// Strip port if present (e.g. "example.com:443").
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	// Return bare IPs unchanged.
+	if net.ParseIP(host) != nil {
+		return host
+	}
+	parts := strings.Split(host, ".")
+	if len(parts) <= 2 {
+		return host
+	}
+	return parts[len(parts)-2] + "." + parts[len(parts)-1]
 }
 
 func (s *service) addToAggregateBuffer(logs []trafficLog, nowMS int64) error {

--- a/main.go
+++ b/main.go
@@ -2218,7 +2218,33 @@ func (s *service) queryAggregate(dimension string, start, end int64) ([]aggregat
 	if err != nil {
 		return nil, err
 	}
-	return s.queryByFilters(column, "", nil, start, end)
+	rows, err := s.queryByFilters(column, "", nil, start, end)
+	if err != nil {
+		return nil, err
+	}
+	if column == "host" && s.currentDomainGroupingEnabled() {
+		rows = groupHostRows(rows)
+	}
+	return rows, nil
+}
+
+func groupHostRows(rows []aggregatedData) []aggregatedData {
+	merged := make(map[string]*aggregatedData, len(rows))
+	for _, row := range rows {
+		key := normalizeHost(row.Label)
+		existing, ok := merged[key]
+		if !ok {
+			copyRow := row
+			copyRow.Label = key
+			merged[key] = &copyRow
+			continue
+		}
+		existing.Upload += row.Upload
+		existing.Download += row.Download
+		existing.Total += row.Total
+		existing.Count += row.Count
+	}
+	return sortedAggregatedDataRows(merged)
 }
 
 func (s *service) querySubstats(dimension, label string, start, end int64) ([]aggregatedData, error) {

--- a/main_test.go
+++ b/main_test.go
@@ -25,7 +25,7 @@ func TestQueryAggregate(t *testing.T) {
 		{BucketStart: 60_000, BucketEnd: 120_000, SourceIP: "192.168.1.3", Host: "a.com", Process: "curl", Outbound: "DIRECT", Chains: `["DIRECT"]`, Upload: 10, Download: 30, Count: 1},
 	})
 
-	got, err := svc.queryAggregate("sourceIP", 1, 120_000)
+	got, err := svc.queryAggregate("sourceIP", 1, 120_000, false)
 	if err != nil {
 		t.Fatalf("queryAggregate: %v", err)
 	}
@@ -2462,7 +2462,7 @@ func TestQueryAggregateIncludesBufferedData(t *testing.T) {
 		Count:         1,
 	}
 
-	got, err := svc.queryAggregate("sourceIP", 60_000, 180_000)
+	got, err := svc.queryAggregate("sourceIP", 60_000, 180_000, false)
 	if err != nil {
 		t.Fatalf("queryAggregate: %v", err)
 	}
@@ -3293,7 +3293,7 @@ func TestQueryAggregateHostGrouping(t *testing.T) {
 			{BucketStart: 0, BucketEnd: 60_000, SourceIP: "192.168.1.2", Host: "www.youtube.com", Outbound: "NodeA", Chains: `["NodeA"]`, Upload: 10, Download: 20, Count: 1},
 		})
 
-		rows, err := svc.queryAggregate("host", 0, 60_000)
+		rows, err := svc.queryAggregate("host", 0, 60_000, false)
 		if err != nil {
 			t.Fatalf("queryAggregate: %v", err)
 		}
@@ -3328,7 +3328,7 @@ func TestQueryAggregateHostGrouping(t *testing.T) {
 			{BucketStart: 0, BucketEnd: 60_000, SourceIP: "192.168.1.2", Host: "r4---sn-xyz.googlevideo.com", Outbound: "NodeA", Chains: `["NodeA"]`, Upload: 50, Download: 80, Count: 2},
 		})
 
-		rows, err := svc.queryAggregate("host", 0, 60_000)
+		rows, err := svc.queryAggregate("host", 0, 60_000, false)
 		if err != nil {
 			t.Fatalf("queryAggregate: %v", err)
 		}
@@ -3344,12 +3344,50 @@ func TestQueryAggregateHostGrouping(t *testing.T) {
 			{BucketStart: 0, BucketEnd: 60_000, SourceIP: "192.168.1.3", Host: "r4---sn-xyz.googlevideo.com", Outbound: "NodeA", Chains: `["NodeA"]`, Upload: 50, Download: 80, Count: 1},
 		})
 
-		rows, err := svc.queryAggregate("sourceIP", 0, 60_000)
+		rows, err := svc.queryAggregate("sourceIP", 0, 60_000, false)
 		if err != nil {
 			t.Fatalf("queryAggregate: %v", err)
 		}
 		if len(rows) != 2 {
 			t.Errorf("expected 2 rows for sourceIP dimension, got %d", len(rows))
+		}
+	})
+}
+
+func TestQueryAggregateRawPassthrough(t *testing.T) {
+	svc := newTestService(t)
+	insertTestAggregates(t, svc.db, []aggregatedEntry{
+		{BucketStart: 0, BucketEnd: 60_000, SourceIP: "192.168.1.2", Host: "r1---sn-abc.googlevideo.com", Outbound: "NodeA", Chains: `["NodeA"]`, Upload: 100, Download: 200, Count: 1},
+		{BucketStart: 0, BucketEnd: 60_000, SourceIP: "192.168.1.2", Host: "r4---sn-xyz.googlevideo.com", Outbound: "NodeA", Chains: `["NodeA"]`, Upload: 50, Download: 80, Count: 2},
+	})
+
+	t.Run("raw=false groups subdomains", func(t *testing.T) {
+		rows, err := svc.queryAggregate("host", 0, 60_000, false)
+		if err != nil {
+			t.Fatalf("queryAggregate: %v", err)
+		}
+		if len(rows) != 1 {
+			t.Errorf("expected 1 grouped row, got %d: %v", len(rows), rows)
+		}
+		if rows[0].Label != "googlevideo.com" {
+			t.Errorf("expected label googlevideo.com, got %s", rows[0].Label)
+		}
+	})
+
+	t.Run("raw=true bypasses grouping", func(t *testing.T) {
+		rows, err := svc.queryAggregate("host", 0, 60_000, true)
+		if err != nil {
+			t.Fatalf("queryAggregate: %v", err)
+		}
+		if len(rows) != 2 {
+			t.Errorf("expected 2 raw rows, got %d: %v", len(rows), rows)
+		}
+		labels := make(map[string]bool)
+		for _, r := range rows {
+			labels[r.Label] = true
+		}
+		if !labels["r1---sn-abc.googlevideo.com"] || !labels["r4---sn-xyz.googlevideo.com"] {
+			t.Errorf("expected raw subdomain labels, got %v", labels)
 		}
 	})
 }

--- a/main_test.go
+++ b/main_test.go
@@ -3048,11 +3048,12 @@ func newTestService(t *testing.T) *service {
 	})
 
 	return &service{
-		db:                db,
-		now:               time.Now,
-		lastConnections:   make(map[string]connection),
-		aggregateBuffer:   make(map[string]*aggregatedEntry),
-		hostMinuteWindows: make(map[string]*hostTrafficWindow),
+		db:                    db,
+		now:                   time.Now,
+		domainGroupingEnabled: loadDomainGroupingEnabled(db),
+		lastConnections:       make(map[string]connection),
+		aggregateBuffer:       make(map[string]*aggregatedEntry),
+		hostMinuteWindows:     make(map[string]*hostTrafficWindow),
 	}
 }
 
@@ -3114,6 +3115,108 @@ type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return fn(req)
+}
+
+func TestDomainGroupingEnabled(t *testing.T) {
+	svc := newTestService(t)
+
+	// Default: no row in DB → returns true
+	if got := loadDomainGroupingEnabled(svc.db); !got {
+		t.Fatal("expected default to be true")
+	}
+
+	// Save false, reload
+	if err := saveDomainGroupingEnabled(svc.db, false); err != nil {
+		t.Fatalf("saveDomainGroupingEnabled(false): %v", err)
+	}
+	if got := loadDomainGroupingEnabled(svc.db); got {
+		t.Fatal("expected false after saving false")
+	}
+
+	// Save true, reload
+	if err := saveDomainGroupingEnabled(svc.db, true); err != nil {
+		t.Fatalf("saveDomainGroupingEnabled(true): %v", err)
+	}
+	if got := loadDomainGroupingEnabled(svc.db); !got {
+		t.Fatal("expected true after saving true")
+	}
+}
+
+func TestHandleDomainGroupingSettings(t *testing.T) {
+	svc := newTestService(t)
+
+	t.Run("GET returns default true", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/settings/domain-grouping", nil)
+		rec := httptest.NewRecorder()
+		svc.routes().ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("GET status %d: %s", rec.Code, rec.Body.String())
+		}
+		var resp map[string]interface{}
+		if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if resp["enabled"] != true {
+			t.Fatalf("expected enabled=true, got %v", resp["enabled"])
+		}
+	})
+
+	t.Run("PUT sets false", func(t *testing.T) {
+		body := bytes.NewBufferString(`{"enabled":false}`)
+		req := httptest.NewRequest(http.MethodPut, "/api/settings/domain-grouping", body)
+		rec := httptest.NewRecorder()
+		svc.routes().ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("PUT status %d: %s", rec.Code, rec.Body.String())
+		}
+		var resp map[string]interface{}
+		if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if resp["enabled"] != false {
+			t.Fatalf("expected enabled=false, got %v", resp["enabled"])
+		}
+		if svc.currentDomainGroupingEnabled() {
+			t.Fatal("expected in-memory state to be false")
+		}
+	})
+
+	t.Run("PUT sets true", func(t *testing.T) {
+		body := bytes.NewBufferString(`{"enabled":true}`)
+		req := httptest.NewRequest(http.MethodPut, "/api/settings/domain-grouping", body)
+		rec := httptest.NewRecorder()
+		svc.routes().ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("PUT status %d: %s", rec.Code, rec.Body.String())
+		}
+		if !svc.currentDomainGroupingEnabled() {
+			t.Fatal("expected in-memory state to be true")
+		}
+	})
+
+	t.Run("PUT bad JSON returns 400", func(t *testing.T) {
+		body := bytes.NewBufferString(`not-json`)
+		req := httptest.NewRequest(http.MethodPut, "/api/settings/domain-grouping", body)
+		rec := httptest.NewRecorder()
+		svc.routes().ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", rec.Code)
+		}
+	})
+
+	t.Run("DELETE returns 405", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodDelete, "/api/settings/domain-grouping", nil)
+		rec := httptest.NewRecorder()
+		svc.routes().ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusMethodNotAllowed {
+			t.Fatalf("expected 405, got %d", rec.Code)
+		}
+	})
 }
 
 func TestNormalizeHost(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -3353,3 +3353,104 @@ func TestQueryAggregateHostGrouping(t *testing.T) {
 		}
 	})
 }
+
+func TestQuerySubstatsHostGrouping(t *testing.T) {
+	t.Run("returns raw subdomains for normalized host when grouping enabled", func(t *testing.T) {
+		svc := newTestService(t)
+		insertTestAggregates(t, svc.db, []aggregatedEntry{
+			{BucketStart: 0, BucketEnd: 60_000, SourceIP: "192.168.1.2", Host: "r1---sn-abc.googlevideo.com", Outbound: "NodeA", Chains: `["NodeA"]`, Upload: 100, Download: 200, Count: 1},
+			{BucketStart: 0, BucketEnd: 60_000, SourceIP: "192.168.1.2", Host: "r4---sn-xyz.googlevideo.com", Outbound: "NodeA", Chains: `["NodeA"]`, Upload: 50, Download: 80, Count: 2},
+			{BucketStart: 0, BucketEnd: 60_000, SourceIP: "192.168.1.2", Host: "www.youtube.com", Outbound: "NodeA", Chains: `["NodeA"]`, Upload: 10, Download: 20, Count: 1},
+		})
+
+		rows, err := svc.querySubstats("host", "googlevideo.com", 0, 60_000)
+		if err != nil {
+			t.Fatalf("querySubstats: %v", err)
+		}
+		if len(rows) != 2 {
+			t.Errorf("expected 2 subdomain rows, got %d: %v", len(rows), rows)
+		}
+		byLabel := make(map[string]aggregatedData)
+		for _, r := range rows {
+			byLabel[r.Label] = r
+		}
+		if _, ok := byLabel["r1---sn-abc.googlevideo.com"]; !ok {
+			t.Error("expected r1---sn-abc.googlevideo.com in results")
+		}
+		if _, ok := byLabel["r4---sn-xyz.googlevideo.com"]; !ok {
+			t.Error("expected r4---sn-xyz.googlevideo.com in results")
+		}
+		if _, ok := byLabel["www.youtube.com"]; ok {
+			t.Error("www.youtube.com should not appear in googlevideo.com substats")
+		}
+	})
+
+	t.Run("returns error when grouping disabled", func(t *testing.T) {
+		svc := newTestService(t)
+		if err := svc.updateDomainGroupingEnabled(false); err != nil {
+			t.Fatalf("updateDomainGroupingEnabled: %v", err)
+		}
+		_, err := svc.querySubstats("host", "googlevideo.com", 0, 60_000)
+		if err == nil {
+			t.Fatal("expected error for host substats when grouping disabled")
+		}
+	})
+
+	t.Run("exact match passes through for bare IP label", func(t *testing.T) {
+		svc := newTestService(t)
+		insertTestAggregates(t, svc.db, []aggregatedEntry{
+			{BucketStart: 0, BucketEnd: 60_000, SourceIP: "192.168.1.2", Host: "192.0.2.1", Outbound: "NodeA", Chains: `["NodeA"]`, Upload: 100, Download: 200, Count: 1},
+			{BucketStart: 0, BucketEnd: 60_000, SourceIP: "192.168.1.2", Host: "example.com", Outbound: "NodeA", Chains: `["NodeA"]`, Upload: 10, Download: 20, Count: 1},
+		})
+
+		rows, err := svc.querySubstats("host", "192.0.2.1", 0, 60_000)
+		if err != nil {
+			t.Fatalf("querySubstats: %v", err)
+		}
+		if len(rows) != 1 {
+			t.Errorf("expected 1 row for bare IP, got %d: %v", len(rows), rows)
+		}
+		if rows[0].Label != "192.0.2.1" {
+			t.Errorf("expected label 192.0.2.1, got %s", rows[0].Label)
+		}
+	})
+}
+
+func TestConnectionDetailsSubdomainSecondary(t *testing.T) {
+	svc := newTestService(t)
+	insertTestAggregates(t, svc.db, []aggregatedEntry{
+		{BucketStart: 0, BucketEnd: 60_000, SourceIP: "192.168.1.2", Host: "r1---sn-abc.googlevideo.com", Outbound: "NodeA", Chains: `["NodeA"]`, Upload: 100, Download: 200, Count: 1},
+		{BucketStart: 0, BucketEnd: 60_000, SourceIP: "192.168.1.3", Host: "r1---sn-abc.googlevideo.com", Outbound: "NodeA", Chains: `["NodeA"]`, Upload: 50, Download: 80, Count: 1},
+		{BucketStart: 0, BucketEnd: 60_000, SourceIP: "192.168.1.2", Host: "r4---sn-xyz.googlevideo.com", Outbound: "NodeA", Chains: `["NodeA"]`, Upload: 10, Download: 20, Count: 1},
+	})
+
+	// secondary is a raw subdomain — should return all source IPs for that host
+	details, err := svc.queryConnectionDetails("host", "googlevideo.com", "r1---sn-abc.googlevideo.com", 0, 60_000)
+	if err != nil {
+		t.Fatalf("queryConnectionDetails: %v", err)
+	}
+	if len(details) != 2 {
+		t.Errorf("expected 2 detail rows (one per source IP), got %d: %v", len(details), details)
+	}
+	sourceIPs := make(map[string]bool)
+	for _, d := range details {
+		sourceIPs[d.SourceIP] = true
+	}
+	if !sourceIPs["192.168.1.2"] || !sourceIPs["192.168.1.3"] {
+		t.Errorf("expected both source IPs, got %v", sourceIPs)
+	}
+
+	// secondary is a source IP — existing behaviour unchanged
+	details, err = svc.queryConnectionDetails("host", "googlevideo.com", "192.168.1.2", 0, 60_000)
+	if err != nil {
+		t.Fatalf("queryConnectionDetails (IP secondary): %v", err)
+	}
+	if len(details) == 0 {
+		t.Error("expected results for source IP secondary")
+	}
+	for _, d := range details {
+		if d.SourceIP != "192.168.1.2" {
+			t.Errorf("expected only source IP 192.168.1.2, got %s", d.SourceIP)
+		}
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -2767,7 +2767,7 @@ func TestEmbeddedIndexDisablesPeriodicAutoRefresh(t *testing.T) {
 			t.Fatalf("expected embedded index.html to contain %q", want)
 		}
 	}
-	if !strings.Contains(script, `sendJSON("/api/settings/mihomo", "PUT", payload)`) {
+	if !strings.Contains(script, `sendJSON("/api/settings/mihomo", "PUT", mihomoPayload)`) {
 		t.Fatalf("expected embedded index.html to save mihomo settings through the settings API")
 	}
 	for _, want := range []string{

--- a/main_test.go
+++ b/main_test.go
@@ -3240,3 +3240,116 @@ func TestNormalizeHost(t *testing.T) {
 		}
 	}
 }
+
+func TestGroupHostRows(t *testing.T) {
+	rows := []aggregatedData{
+		{Label: "r1---sn-abc.googlevideo.com", Upload: 100, Download: 200, Total: 300, Count: 1},
+		{Label: "r4---sn-xyz.googlevideo.com", Upload: 50, Download: 80, Total: 130, Count: 2},
+		{Label: "www.youtube.com", Upload: 10, Download: 20, Total: 30, Count: 1},
+		{Label: "91.108.56.111", Upload: 5, Download: 5, Total: 10, Count: 1},
+	}
+	got := groupHostRows(rows)
+
+	byLabel := make(map[string]aggregatedData, len(got))
+	for _, r := range got {
+		byLabel[r.Label] = r
+	}
+
+	gv, ok := byLabel["googlevideo.com"]
+	if !ok {
+		t.Fatal("expected googlevideo.com in result")
+	}
+	if gv.Upload != 150 || gv.Download != 280 || gv.Total != 430 || gv.Count != 3 {
+		t.Errorf("googlevideo.com unexpected: %+v", gv)
+	}
+
+	yt, ok := byLabel["youtube.com"]
+	if !ok {
+		t.Fatal("expected youtube.com in result")
+	}
+	if yt.Upload != 10 || yt.Download != 20 || yt.Total != 30 {
+		t.Errorf("youtube.com unexpected: %+v", yt)
+	}
+
+	ip, ok := byLabel["91.108.56.111"]
+	if !ok {
+		t.Fatal("expected bare IP in result")
+	}
+	if ip.Total != 10 {
+		t.Errorf("bare IP unexpected: %+v", ip)
+	}
+
+	if len(got) != 3 {
+		t.Errorf("expected 3 rows after grouping, got %d", len(got))
+	}
+}
+
+func TestQueryAggregateHostGrouping(t *testing.T) {
+	t.Run("groups subdomains when enabled", func(t *testing.T) {
+		svc := newTestService(t)
+		insertTestAggregates(t, svc.db, []aggregatedEntry{
+			{BucketStart: 0, BucketEnd: 60_000, SourceIP: "192.168.1.2", Host: "r1---sn-abc.googlevideo.com", Outbound: "NodeA", Chains: `["NodeA"]`, Upload: 100, Download: 200, Count: 1},
+			{BucketStart: 0, BucketEnd: 60_000, SourceIP: "192.168.1.2", Host: "r4---sn-xyz.googlevideo.com", Outbound: "NodeA", Chains: `["NodeA"]`, Upload: 50, Download: 80, Count: 2},
+			{BucketStart: 0, BucketEnd: 60_000, SourceIP: "192.168.1.2", Host: "www.youtube.com", Outbound: "NodeA", Chains: `["NodeA"]`, Upload: 10, Download: 20, Count: 1},
+		})
+
+		rows, err := svc.queryAggregate("host", 0, 60_000)
+		if err != nil {
+			t.Fatalf("queryAggregate: %v", err)
+		}
+
+		byLabel := make(map[string]aggregatedData)
+		for _, r := range rows {
+			byLabel[r.Label] = r
+		}
+
+		gv, ok := byLabel["googlevideo.com"]
+		if !ok {
+			t.Fatal("expected googlevideo.com grouped row")
+		}
+		if gv.Upload != 150 || gv.Download != 280 || gv.Count != 3 {
+			t.Errorf("googlevideo.com unexpected: %+v", gv)
+		}
+		if _, raw := byLabel["r1---sn-abc.googlevideo.com"]; raw {
+			t.Error("raw subdomain r1---sn-abc.googlevideo.com should not appear when grouping enabled")
+		}
+		if len(rows) != 2 {
+			t.Errorf("expected 2 rows (googlevideo.com + youtube.com), got %d: %v", len(rows), rows)
+		}
+	})
+
+	t.Run("returns raw hosts when grouping disabled", func(t *testing.T) {
+		svc := newTestService(t)
+		if err := svc.updateDomainGroupingEnabled(false); err != nil {
+			t.Fatalf("updateDomainGroupingEnabled: %v", err)
+		}
+		insertTestAggregates(t, svc.db, []aggregatedEntry{
+			{BucketStart: 0, BucketEnd: 60_000, SourceIP: "192.168.1.2", Host: "r1---sn-abc.googlevideo.com", Outbound: "NodeA", Chains: `["NodeA"]`, Upload: 100, Download: 200, Count: 1},
+			{BucketStart: 0, BucketEnd: 60_000, SourceIP: "192.168.1.2", Host: "r4---sn-xyz.googlevideo.com", Outbound: "NodeA", Chains: `["NodeA"]`, Upload: 50, Download: 80, Count: 2},
+		})
+
+		rows, err := svc.queryAggregate("host", 0, 60_000)
+		if err != nil {
+			t.Fatalf("queryAggregate: %v", err)
+		}
+		if len(rows) != 2 {
+			t.Errorf("expected 2 raw rows when grouping disabled, got %d", len(rows))
+		}
+	})
+
+	t.Run("non-host dimensions are not grouped", func(t *testing.T) {
+		svc := newTestService(t)
+		insertTestAggregates(t, svc.db, []aggregatedEntry{
+			{BucketStart: 0, BucketEnd: 60_000, SourceIP: "192.168.1.2", Host: "r1---sn-abc.googlevideo.com", Outbound: "NodeA", Chains: `["NodeA"]`, Upload: 100, Download: 200, Count: 1},
+			{BucketStart: 0, BucketEnd: 60_000, SourceIP: "192.168.1.3", Host: "r4---sn-xyz.googlevideo.com", Outbound: "NodeA", Chains: `["NodeA"]`, Upload: 50, Download: 80, Count: 1},
+		})
+
+		rows, err := svc.queryAggregate("sourceIP", 0, 60_000)
+		if err != nil {
+			t.Fatalf("queryAggregate: %v", err)
+		}
+		if len(rows) != 2 {
+			t.Errorf("expected 2 rows for sourceIP dimension, got %d", len(rows))
+		}
+	})
+}

--- a/main_test.go
+++ b/main_test.go
@@ -3115,3 +3115,25 @@ type roundTripFunc func(*http.Request) (*http.Response, error)
 func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return fn(req)
 }
+
+func TestNormalizeHost(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"r1---sn-abc.googlevideo.com", "googlevideo.com"},
+		{"www.youtube.com", "youtube.com"},
+		{"91.108.56.111", "91.108.56.111"},
+		{"2001:db8::1", "2001:db8::1"},
+		{"youtube.com", "youtube.com"},
+		{"localhost", "localhost"},
+		{"example.com:443", "example.com"},
+		{"sub.sub.example.com", "example.com"},
+	}
+	for _, c := range cases {
+		got := normalizeHost(c.input)
+		if got != c.want {
+			t.Errorf("normalizeHost(%q) = %q, want %q", c.input, got, c.want)
+		}
+	}
+}

--- a/web/app.js
+++ b/web/app.js
@@ -354,12 +354,17 @@ function buildAutoSwitchSummary() {
 
 function updateViewHints() {
   const config = drilldownConfig[elements.dimension.value] || drilldownConfig.sourceIP
-  const secondaryTitle = config.buildSecondaryTitle(state.selectedPrimary)
+  const groupedHostMode = elements.dimension.value === "host" && state.domainGroupingEnabled
+
+  const secondaryColumn = groupedHostMode ? "子域名" : config.secondaryColumn
+  const secondaryTitle = groupedHostMode
+    ? (state.selectedPrimary ? `${state.selectedPrimary} 的子域名` : "子域名")
+    : config.buildSecondaryTitle(state.selectedPrimary)
   const detailTitle = config.buildDetailTitle(state.selectedPrimary, state.selectedSecondary)
 
   elements.countLabel.textContent = config.countLabel
   elements.primaryTitle.textContent = config.primaryTitle
-  elements.secondaryHeader.textContent = config.secondaryColumn
+  elements.secondaryHeader.textContent = secondaryColumn
   elements.secondaryTitle.textContent = secondaryTitle
   elements.secondaryTitle.title = secondaryTitle
   elements.detailTitle.textContent = detailTitle
@@ -1045,16 +1050,22 @@ async function loadSecondaryRows(primaryLabel) {
 
   let path = "/api/traffic/substats"
   let params
+  let subdomainMode = false
   if (dimension === "host") {
-    path = "/api/traffic/devices-by-host"
-    params = { host: primaryLabel, start, end }
+    if (state.domainGroupingEnabled) {
+      subdomainMode = true
+      params = { dimension: "host", label: primaryLabel, start, end }
+    } else {
+      path = "/api/traffic/devices-by-host"
+      params = { host: primaryLabel, start, end }
+    }
   } else {
     params = { dimension, label: primaryLabel, start, end }
   }
 
   const rows = await fetchJSON(path, params)
   state.secondaryRows = rows
-  state.selectedSecondary = rows[0]?.label || null
+  state.selectedSecondary = subdomainMode ? null : (rows[0]?.label || null)
   renderSecondaryTable(rows)
   updateViewHints()
 

--- a/web/app.js
+++ b/web/app.js
@@ -58,6 +58,7 @@ const elements = {
   settingsSecret: document.getElementById("settingsSecret"),
   settingsSaveBtn: document.getElementById("settingsSaveBtn"),
   settingsCancelBtn: document.getElementById("settingsCancelBtn"),
+  domainGroupingEnabled: document.getElementById("domainGroupingEnabled"),
   settingsCloseBtn: document.getElementById("settingsCloseBtn"),
   settingsBtn: document.getElementById("settingsBtn"),
   autoSwitchBtn: document.getElementById("autoSwitchBtn"),
@@ -112,6 +113,7 @@ const state = {
     url: "",
     secret: "",
   },
+  domainGroupingEnabled: false,
   settingsOpen: false,
   settingsRequired: false,
   autoSwitchOpen: false,
@@ -408,6 +410,7 @@ async function sendJSON(path, method, payload) {
 function syncSettingsForm() {
   elements.settingsUrl.value = state.mihomoSettings.url || ""
   elements.settingsSecret.value = state.mihomoSettings.secret || ""
+  elements.domainGroupingEnabled.checked = Boolean(state.domainGroupingEnabled)
 }
 
 function syncSettingsUI() {
@@ -608,11 +611,15 @@ function collectAutoSwitchGroupTargets() {
 }
 
 async function loadSettings() {
-  const settings = await fetchJSON("/api/settings/mihomo")
+  const [settings, grouping] = await Promise.all([
+    fetchJSON("/api/settings/mihomo"),
+    fetchJSON("/api/settings/domain-grouping"),
+  ])
   state.mihomoSettings = {
     url: settings.url || "",
     secret: settings.secret || "",
   }
+  state.domainGroupingEnabled = Boolean(grouping.enabled)
   state.settingsRequired = !state.mihomoSettings.url
   state.settingsOpen = state.settingsRequired
   syncSettingsForm()
@@ -659,30 +666,35 @@ function handleModalClose(event) {
 async function saveSettings(event) {
   event.preventDefault()
 
-  const payload = {
+  const mihomoPayload = {
     url: elements.settingsUrl.value.trim(),
     secret: elements.settingsSecret.value.trim(),
   }
+  const groupingPayload = { enabled: elements.domainGroupingEnabled.checked }
 
   elements.settingsSaveBtn.disabled = true
-  setStatus("正在保存 Mihomo 设置...")
+  setStatus("正在保存设置...")
 
   try {
-    const saved = await sendJSON("/api/settings/mihomo", "PUT", payload)
+    const [saved] = await Promise.all([
+      sendJSON("/api/settings/mihomo", "PUT", mihomoPayload),
+      sendJSON("/api/settings/domain-grouping", "PUT", groupingPayload),
+    ])
     state.mihomoSettings = {
       url: saved.url || "",
       secret: saved.secret || "",
     }
+    state.domainGroupingEnabled = groupingPayload.enabled
     state.settingsRequired = !state.mihomoSettings.url
     state.settingsOpen = false
     syncSettingsForm()
     syncSettingsUI()
-    setStatus("Mihomo 设置已保存")
+    setStatus("设置已保存")
     await refreshAutoSwitchData()
     await loadData()
   } catch (error) {
     console.error(error)
-    setStatus(error.message || "保存 Mihomo 设置失败", true)
+    setStatus(error.message || "保存设置失败", true)
   } finally {
     elements.settingsSaveBtn.disabled = false
   }

--- a/web/index.html
+++ b/web/index.html
@@ -142,6 +142,10 @@
                   autocomplete="off"
                 />
               </label>
+              <label class="settings-field checkbox-field">
+                <span>域名分组</span>
+                <input id="domainGroupingEnabled" type="checkbox" />
+              </label>
               <div class="settings-actions">
                 <button id="settingsSaveBtn" class="toolbar-action primary" type="submit">
                   保存并连接


### PR DESCRIPTION
Closes #4

## Problem

CDN-heavy services (YouTube, Netflix, Akamai) scatter traffic across dozens of ephemeral subdomains. A single YouTube session currently produces 20+ rows like:

```
r1---sn-abc123.googlevideo.com      82 MB
r4---sn-xyz789.googlevideo.com      61 MB
rr3---sn-def456.googlevideo.com     47 MB
...
```

The host list becomes noisy and the total traffic for a service — the number users actually care about — is invisible.

## What This PR Does (Phase 1)

Automatically groups subdomains to their **eTLD+1 root** at query time, with full drill-down:

```
googlevideo.com    229 MB    ▶ click to see subdomains
```

- **Query-time normalization** — raw hostnames are preserved in SQLite; grouping is applied on read. Rule changes are retroactive at zero cost.
- **Drill-down preserved** — clicking a grouped row shows raw subdomains in the secondary panel; clicking a subdomain shows per-source-IP connection details.
- **Global toggle** — a checkbox in the Settings modal enables/disables grouping. The setting persists to `app_settings`.
- **`?raw=1` escape hatch** — any API call can bypass grouping without touching the global setting.
- **`normalizeHost()` is a seam** — replacing it with a proper Public Suffix List (PSL) lookup in a future phase requires changing exactly one function.

**Known limitation of the heuristic:** multi-part TLDs (`bbc.co.uk → co.uk`, `user.github.io → github.io`) are grouped incorrectly. Acceptable until a PSL upgrade is added.

## What's Not Included (Phase 2)

Phase 2 would add a `label_rules` table for user-defined rules — mapping CIDR ranges (e.g. `91.108.0.0/16 → Telegram`) or wildcard domains to custom labels.

## Design

Full design doc with architecture, trade-offs, API reference, and schema: [2027-04-29-domain-grouping-design.md](https://github.com/dannierl/clash-traffic-monitor/blob/domain-grouping/docs/superpowers/specs/2027-04-29-domain-grouping-design.md)

## Changes

- `main.go`: `normalizeHost()`, `domain_grouping_enabled` setting R/W, post-query merge in `queryAggregate`, LIKE match in substats drill-down, `?raw=1` parameter
- `web/`: domain grouping checkbox in Settings modal, subdomain secondary panel routing
- `main_test.go`: unit tests for all new functions