### PR TITLE
fix: initialize aggregateRetentionDays in newTestService

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -3153,12 +3153,13 @@ func newTestService(t *testing.T) *service {
 	})
 
 	return &service{
-		db:                    db,
-		now:                   time.Now,
-		domainGroupingEnabled: loadDomainGroupingEnabled(db),
-		lastConnections:       make(map[string]connection),
-		aggregateBuffer:       make(map[string]*aggregatedEntry),
-		hostMinuteWindows:     make(map[string]*hostTrafficWindow),
+		db:                     db,
+		now:                    time.Now,
+		domainGroupingEnabled:  loadDomainGroupingEnabled(db),
+		aggregateRetentionDays: loadRetentionDays(db),
+		lastConnections:        make(map[string]connection),
+		aggregateBuffer:        make(map[string]*aggregatedEntry),
+		hostMinuteWindows:      make(map[string]*hostTrafficWindow),
 	}
 }
 


### PR DESCRIPTION
Fixes #7

## Summary

- `newTestService` did not initialize `aggregateRetentionDays`, leaving it at `0`
- `cleanupOldLogs` computed a cutoff of `now - 0 = now`, deleting all aggregate rows and causing `TestCleanupOldLogsKeepsThirtyDaysOfAggregates` to always fail
- Fix: call `loadRetentionDays(db)` in `newTestService`, matching how the production `service` is constructed (returns default of 30 days for a fresh DB)

## Test plan

- [x] `go test -run TestCleanupOldLogsKeepsThirtyDaysOfAggregates ./...` passes
- [x] `go test ./...` passes (full suite clean)